### PR TITLE
Rewrote `neuro.train` to represent headless infinite sequence

### DIFF
--- a/examples/mnist/src/mnist/core.clj
+++ b/examples/mnist/src/mnist/core.clj
@@ -13,68 +13,71 @@
    :softmax 10))
 
 (def train-size 60000)
+(def test-size 100)
 
 (def my-data (let [[img lbl] (md/load-train)
                    perm (vl/gen-perm img)
                    imgr (vl/shuffle img perm)
                    lblr (vl/shuffle lbl perm)]
                [imgr lblr]))
-(def test-data (map #(vl/slice % 0 1000) my-data))
-(def train-data (map #(vl/slice % 1000 train-size) my-data))
+(def test-data (map #(vl/slice % 0 test-size) my-data))
+(def train-data (map #(vl/slice % test-size (+ test-size train-size)) my-data))
 
 (defn evaluate [net [img-vol label-vol]]
   (let [done (nc/feedforward net img-vol)
-        check (pmap (fn [done-vol lbl-vol]
+        check (map (fn [done-vol lbl-vol]
                       (= (md/vol->digit done-vol)
                          (md/vol->digit lbl-vol)))
                     (vl/rows done)
                     (vl/rows label-vol))]
     (count (filter true? check))))
 
-(def ^:private start-time-now-epoch (atom 0))
+(def ^:private start-time-now-epoch (atom (System/currentTimeMillis)))
 
 (def test-error-rates (atom []))
 
-(defn report [ep net]
+(defn report [{net :model, ep :epoch}]
   (let [ok (evaluate net test-data)
         [n _] (vl/shape (first test-data))
         elapsed (- (System/currentTimeMillis) @start-time-now-epoch)]
-    (printf "\nepoch %d: %d / %d  (%4.2f min)\n" ep ok n (float (/ elapsed 60000.0)))
+    (printf "epoch %d: %d / %d  (%4.2f min)\n" ep ok n (float (/ elapsed 60000.0)))
     (flush)
     (swap! test-error-rates conj (- 1.0 (/ (float ok) (float n))))
     (reset! start-time-now-epoch (System/currentTimeMillis))
 ;    (sh "say" (str "epoc " ep " " (float (* 100 (/ ok n))))) ; for mac user
     ))
 
-(defn mini-batch-report [net loss]
-  (print "."))
+(defn mini-batch-report [_]
+  (print ".")
+  (flush))
 
-
-(def mnist-train-status (atom nil))
 
 (defn train
   ([] (train net))
   ([net]
    (reset! start-time-now-epoch (System/currentTimeMillis))
    (reset! test-error-rates [])
-   (reset! mnist-train-status (nt/new-status))
-   (nc/with-params [:train-status-var mnist-train-status
-                    :mini-batch-size 20
-                    :epoch-limit 30
-                    :learning-rate 1.0
-                    :epoch-reporter report
-                    :mini-batch-reporter mini-batch-report]
-     (let [[img-vol lbl-vol] train-data]
-       (nc/sgd net img-vol lbl-vol)))))
+   (let [learning-rate 1.0
+         limit         10
+         size          20
+         batchs (nt/split-mini-batch train-data size)
+         f (nt/iterate-mini-batch-train-fn net batchs)]
+     (->> (f (nt/gen-sgd-optimizer learning-rate))
+          (nt/with-epoch-report report)
+          (drop-while #(< (:epoch %) limit))
+          (first)))))
 
 
-(defn print-time-to-next-epoch []
-  (let [{nb :num-batchs, tlh :train-loss-history} @mnist-train-status
-        done-batchs (mod (count tlh) nb)
-        now-elapsed (- (System/currentTimeMillis) @start-time-now-epoch)
-        msec-per-batch (if (zero? done-batchs)
-                         now-elapsed
-                         (/ now-elapsed done-batchs))
-        until-msec (* (- nb done-batchs) msec-per-batch)]
-    (printf "start next epoch at %4.2f min later\n"
-            (float (/ until-msec 60000)))))
+
+(comment
+  (def train-seq-fn
+    (let [batchs (neuro.train/split-mini-batch train-data 20)]
+      (neuro.train/iterate-mini-batch-train-fn net batchs)))
+
+  (reset! start-time-now-epoch (System/currentTimeMillis))
+  (->> (train-seq-fn (neuro.train/gen-sgd-optimizer 1.0))
+       (neuro.train/with-epoch-report report)
+       (drop-while #(< (:epoch %) 10))
+       (first)
+       (:loss))
+)

--- a/src/neuro/core.clj
+++ b/src/neuro/core.clj
@@ -12,6 +12,10 @@
 
 (defalias gen-net nw/gen-net)
 (defalias feedforward nw/feedforward)
-(defalias with-params tr/with-params)
-(defalias init! tr/init!)
-(defalias sgd tr/sgd)
+
+(defalias iterate-train-fn tr/iterate-train-fn)
+(defalias iterate-mini-batch-train-fn tr/iterate-mini-batch-train-fn)
+(defalias split-mini-batch tr/split-mini-batch)
+(defalias gen-sgd-optimizer tr/gen-sgd-optimizer)
+
+(defalias with-epoch-report tr/with-epoch-report)


### PR DESCRIPTION
The train process is written as infinite sequence.
If user doesn't have a sequence head, it's equivalent to loop.
[lazy\-seq in Clojure \(翻訳\)\. https://medium\.com/lazy\-eval/lazy\-seq\-in… \| by Takanori Ishibashi \| Medium](https://medium.com/@11Takanori/lazy-seq-in-clojure-%E7%BF%BB%E8%A8%B3-8fba0ebcb6af)

Sequence utility function can be used for train operation.

```clj
;; master
(neuro.train/with-params [:epoch-limit 30
                          :mini-batch-size 20
                          :learning-rate 1.0
                          :train-status-var train-status
                          :epoch-reporter report]
  (let [[in-vol ans-vol] train-data]
    (neuro.train/sgd net in-vol ans-vol)))



;; this branch
(let [batchs (neuro.train/split-mini-batch train-data 20)
      f (neuro.train/iterate-mini-batch-train-fn net batchs)]
  (->> (f (neuro.train/gen-sgd-optimizer 1.0))
       (neuro.train/with-epoch-report report)
       (drop-while #(< (:epoch %) 30))
       (first)))
```