### PR TITLE
Changed vol.dot to work in parallel

### DIFF
--- a/src/neuro/vol.clj
+++ b/src/neuro/vol.clj
@@ -113,6 +113,13 @@
            :shape [len row]
            :posf (gen-posf [len row] (fn [c r] (pos v (+ c start-col) r))))))
 
+(defn take-slice [n v]
+  (slice v 0 n))
+
+(defn drop-slice [n v]
+  (let [[len _] (shape v)]
+    (slice v n len)))
+
 (defn rows
   ([v]
    (let [[len _] (shape v)]

--- a/src/neuro/vol.clj
+++ b/src/neuro/vol.clj
@@ -145,8 +145,8 @@
            :shape [row col]
            :posf (gen-posf [row col] (fn [c r] (pos v r c))))))
 
-(defn dot
-  "w行列の掛け算 (dot [N M] [M K]) = [N K]"
+
+(defn- dot-serial
   [v1 v2]
   (let [[col1 row1] (shape v1)
         [col2 row2] (shape v2)]
@@ -163,6 +163,28 @@
                                      (recur (inc i)
                                             (+ acc (* (wget v1 c i)
                                                       (wget v2 i r)))))))))))))
+
+(defn- dot-conc
+  [v1 v2]
+  (let [[col1 row1] (shape v1)
+        [col2 row2] (shape v2)]
+    (let [rs1 (map raw-vec (rows v1))
+          rs2 (map raw-vec (rows (T v2)))]
+      (vol col1 row2
+           (vec
+            (pmap (fn [[r1 r2]] (apply + (map * r1 r2)))
+                  (for [r1 rs1, r2 rs2]
+                    [r1 r2])))))))
+
+(defn dot
+  "w行列の掛け算 (dot [N M] [M K]) = [N K]"
+  [v1 v2]
+  (let [[c _] (shape v1)
+        [_ r] (shape v2)]
+    (if (< 100 (* c r))
+      (dot-conc v1 v2)
+      (dot-serial v1 v2))))
+
 
 
 (defn w-elm-op [f this other]

--- a/src/neuro/vol.clj
+++ b/src/neuro/vol.clj
@@ -146,6 +146,19 @@
            :posf (gen-posf [row col] (fn [c r] (pos v r c))))))
 
 
+(def ^:dynamic *dot-parallel-threshold* 120)
+
+(declare dot-serial dot-parallel)
+
+(defn dot
+  "w行列の掛け算 (dot [N M] [M K]) = [N K]"
+  [v1 v2]
+  (let [[c _] (shape v1)
+        [_ r] (shape v2)]
+    (if (<= *dot-parallel-threshold* (* c r))
+      (dot-parallel v1 v2)
+      (dot-serial v1 v2))))
+
 (defn- dot-serial
   [v1 v2]
   (let [[col1 row1] (shape v1)
@@ -164,7 +177,7 @@
                                             (+ acc (* (wget v1 c i)
                                                       (wget v2 i r)))))))))))))
 
-(defn- dot-conc
+(defn- dot-parallel
   [v1 v2]
   (let [[col1 row1] (shape v1)
         [col2 row2] (shape v2)]
@@ -175,15 +188,6 @@
             (pmap (fn [[r1 r2]] (apply + (map * r1 r2)))
                   (for [r1 rs1, r2 rs2]
                     [r1 r2])))))))
-
-(defn dot
-  "w行列の掛け算 (dot [N M] [M K]) = [N K]"
-  [v1 v2]
-  (let [[c _] (shape v1)
-        [_ r] (shape v2)]
-    (if (< 100 (* c r))
-      (dot-conc v1 v2)
-      (dot-serial v1 v2))))
 
 
 


### PR DESCRIPTION
When `col * row` is above the threshold `neuro.vol/*dot-parallel-threshold*`, changed vol.dot to work in parallel.

```clj
;; master
> (let [v1 (vl/rand 30 30)
        v2 (vl/rand 30 30)]
     (time (dotimes [_ 1000]
              (vl/dot v1 v2))))
"Elapsed time: 9372.722786 msecs"

;; this branch
> (let [v1 (vl/rand 30 30)
        v2 (vl/rand 30 30)]
    (time (dotimes [_ 1000]
              (vl/dot v1 v2))))
"Elapsed time: 4093.972453 msecs"
```
